### PR TITLE
added origin_len, docstrings and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,12 @@ assert list(ad.items()) == [('x', 10), ('Xx', 10)]
 ```python
 assert list(ad.origin_keys()) == ['x', 'y']
 ```
+- origin_len
+<br>(get original dict <i>length</i> without aliases)
+```python
+ad = AliasDict({"a": 1, "b": 2})
+ad.add_alias("a", "aa")
+assert list(ad.keys()) == ["a", "b", "aa"]
+assert len(ad) == 3
+assert ad.origin_len() == 2
+```

--- a/aldict/alias_dict.py
+++ b/aldict/alias_dict.py
@@ -8,9 +8,10 @@ class AliasDict(UserDict):
 
     def __init__(self, dict_):
         self._alias_dict = {}
-        super().__init__(self, **dict_)
+        super().__init__(**dict_)
 
     def add_alias(self, key, *aliases):
+        """Adds one or more aliases to specified key in the dictionary"""
         if key not in self.data.keys():
             raise KeyError(key)
         for alias in aliases:
@@ -19,6 +20,7 @@ class AliasDict(UserDict):
             self._alias_dict[alias] = key
 
     def remove_alias(self, *aliases):
+        """Removes one or more aliases"""
         for alias in aliases:
             try:
                 self._alias_dict.__delitem__(alias)
@@ -26,28 +28,42 @@ class AliasDict(UserDict):
                 raise AliasError(alias) from e
 
     def clear_aliases(self):
+        """Removes all aliases"""
         self._alias_dict.clear()
 
     def aliases(self):
+        """Returns all aliases present in the dictionary"""
         return self._alias_dict.keys()
 
     def aliased_keys(self):
+        """Returns a dictview of all keys with their corresponding aliases"""
         result = defaultdict(list)
         for alias, key in self._alias_dict.items():
             result[key].append(alias)
         return result.items()
 
     def origin_keys(self):
+        """Returns all keys"""
         return self.data.keys()
 
     def keys(self):
+        """Returns all keys and aliases"""
         return dict(**self.data, **self._alias_dict).keys()
 
     def values(self):
+        """Returns all values"""
         return self.data.values()
 
     def items(self):
+        """Returns a dictview with all items (including alias/value tuples)"""
         return dict(**self.data, **{k: self.data[v] for k, v in self._alias_dict.items()}).items()
+
+    def origin_len(self):
+        """Returns the length of the original dictionary (without aliases)"""
+        return len(self.data)
+
+    def __len__(self):
+        return len(self.keys())
 
     def __missing__(self, key):
         try:
@@ -76,9 +92,6 @@ class AliasDict(UserDict):
     def __iter__(self):
         for item in self.keys():
             yield item
-
-    def __len__(self):
-        return len(self.keys())
 
     def __repr__(self):
         return f"AliasDict({self.items()})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aldict"
-version = "1.0.0"
+version = "1.1.0"
 readme = "README.md"
 authors = [{ name = "Kaloyan Ivanov", email = "kaloyan.ivanov88@gmail.com" }]
 description = "Multi-key dictionary, supports adding and manipulating key-aliases pointing to shared values"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aldict"
-version = "1.1.0"
+version = "1.0.1"
 readme = "README.md"
 authors = [{ name = "Kaloyan Ivanov", email = "kaloyan.ivanov88@gmail.com" }]
 description = "Multi-key dictionary, supports adding and manipulating key-aliases pointing to shared values"

--- a/tests/test_alias_dict.py
+++ b/tests/test_alias_dict.py
@@ -194,6 +194,11 @@ def test_dict_len_includes_aliases(alias_dict):
     assert len(alias_dict) == 4
 
 
+def test_dict_origin_len_excludes_aliases(alias_dict):
+    assert list(alias_dict.keys()) == [".json", ".yaml", ".toml", ".yml"]
+    assert alias_dict.origin_len() == 3
+
+
 def test_popitem(alias_dict):
     # pops first item -> MutableMapping.popitem()
     assert alias_dict.popitem() == (


### PR DESCRIPTION
## Summary by Sourcery

Add the 'origin_len' method to the AliasDict class, update documentation with new examples, and include tests for the new functionality. Enhance code readability by adding docstrings to all methods. Update the project version to 1.1.0.

New Features:
- Introduce the 'origin_len' method to return the length of the original dictionary without aliases.

Enhancements:
- Add docstrings to all methods in the AliasDict class to improve code readability and understanding.

Documentation:
- Update README.md to include documentation and examples for the new 'origin_len' method.

Tests:
- Add a new test to verify that the 'origin_len' method correctly excludes aliases from the count.

Chores:
- Bump the project version from 1.0.0 to 1.1.0 in pyproject.toml to reflect new changes.